### PR TITLE
Fix Roadmap section animation

### DIFF
--- a/src/Components/RoadMap.js
+++ b/src/Components/RoadMap.js
@@ -65,7 +65,7 @@ const RoadMap = () => {
                   color='aqua'
                   className='aos-init'
                   data-aos='fade-down'
-                  data-aos-delay='1000'>
+                  data-aos-delay='150'>
                   <h4>ONEMOON Community Founded</h4>
                   <p>
                      The early concept of a frictionless yield generation asset was born, for the first time seen on Harmony ONE, ONEMOON is the original deflationary on Harmony!  The Community Project


### PR DESCRIPTION
Previously, when user scrolled down to "Roadmap" section, they saw first part of roadmap ("Q1 2021") appear after ones that are following it. 

This sets animation timeout to 150ms for all of the roadmap items.