### PR TITLE
Moving green blinker from 'Fundraiser' to 'Live Chat' in Top Nav

### DIFF
--- a/src/Components/Navbar.js
+++ b/src/Components/Navbar.js
@@ -55,7 +55,7 @@ const Navbar = () => {
                 <li className='nav-item'>
                   <a target="_blank" href='https://t.me/mochiswaponemoon' className='nav-link'>
                     LIVE CHAT
-                    <span className=''></span>
+                    <span className='video-play-button'></span>
                   </a>
                 </li>
                 <li className='nav-item'>


### PR DESCRIPTION
Moving blinking green light from "Fundraiser" to "Live Chat" to indicate that Onemoon has a livechat online 24/7